### PR TITLE
Add browser based goots picker

### DIFF
--- a/picker/index.html
+++ b/picker/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<link rel="stylesheet" href="style.css">
+	<script src="script.js" defer></script>
+
+	<title>Goots Gallery</title>
+	<meta name="description" content="The ultimate goots viewing experience.">
+</head>
+<body>
+<main>
+
+<!--
+Re-generate by running the following in the goots/ directory and pasting the result in here:
+ls | sed -ne 's|\(.*\)\.\(.*\)|<img src="../goots/\1.\2" alt=":\1:" title=":\1:" height="128" width="128">|p' | pbcopy
+-->
+
+<img src="../goots/angry-goots.png" alt=":angry-goots:" title=":angry-goots:" height="128" width="128">
+<img src="../goots/artificial-goots.png" alt=":artificial-goots:" title=":artificial-goots:" height="128" width="128">
+<img src="../goots/audiogoots.png" alt=":audiogoots:" title=":audiogoots:" height="128" width="128">
+<img src="../goots/bank-of-goots.png" alt=":bank-of-goots:" title=":bank-of-goots:" height="128" width="128">
+<img src="../goots/bank-of-goots2.png" alt=":bank-of-goots2:" title=":bank-of-goots2:" height="128" width="128">
+<img src="../goots/confu-goots.png" alt=":confu-goots:" title=":confu-goots:" height="128" width="128">
+<img src="../goots/dead-code-goots.png" alt=":dead-code-goots:" title=":dead-code-goots:" height="128" width="128">
+<img src="../goots/eugene-goots.png" alt=":eugene-goots:" title=":eugene-goots:" height="128" width="128">
+<img src="../goots/fingie-goots.png" alt=":fingie-goots:" title=":fingie-goots:" height="128" width="128">
+<img src="../goots/goot-question.png" alt=":goot-question:" title=":goot-question:" height="128" width="128">
+<img src="../goots/goot-toot-toot.png" alt=":goot-toot-toot:" title=":goot-toot-toot:" height="128" width="128">
+<img src="../goots/gootprised.png" alt=":gootprised:" title=":gootprised:" height="128" width="128">
+<img src="../goots/gootrage.png" alt=":gootrage:" title=":gootrage:" height="128" width="128">
+<img src="../goots/goots-80s-mullet-man.png" alt=":goots-80s-mullet-man:" title=":goots-80s-mullet-man:" height="128" width="128">
+<img src="../goots/goots-angry.png" alt=":goots-angry:" title=":goots-angry:" height="128" width="128">
+<img src="../goots/goots-cant-hear.png" alt=":goots-cant-hear:" title=":goots-cant-hear:" height="128" width="128">
+<img src="../goots/goots-celebration.png" alt=":goots-celebration:" title=":goots-celebration:" height="128" width="128">
+<img src="../goots/goots-embarassed.png" alt=":goots-embarassed:" title=":goots-embarassed:" height="128" width="128">
+<img src="../goots/goots-fight.png" alt=":goots-fight:" title=":goots-fight:" height="128" width="128">
+<img src="../goots/goots-heart.png" alt=":goots-heart:" title=":goots-heart:" height="128" width="128">
+<img src="../goots/goots-idea.png" alt=":goots-idea:" title=":goots-idea:" height="128" width="128">
+<img src="../goots/goots-intrigued.png" alt=":goots-intrigued:" title=":goots-intrigued:" height="128" width="128">
+<img src="../goots/goots-no-audio.png" alt=":goots-no-audio:" title=":goots-no-audio:" height="128" width="128">
+<img src="../goots/goots-no-no.png" alt=":goots-no-no:" title=":goots-no-no:" height="128" width="128">
+<img src="../goots/goots-no.png" alt=":goots-no:" title=":goots-no:" height="128" width="128">
+<img src="../goots/goots-oh-no.png" alt=":goots-oh-no:" title=":goots-oh-no:" height="128" width="128">
+<img src="../goots/goots-salute.png" alt=":goots-salute:" title=":goots-salute:" height="128" width="128">
+<img src="../goots/goots-working.png" alt=":goots-working:" title=":goots-working:" height="128" width="128">
+<img src="../goots/goots-yay.png" alt=":goots-yay:" title=":goots-yay:" height="128" width="128">
+<img src="../goots/goots-yes.png" alt=":goots-yes:" title=":goots-yes:" height="128" width="128">
+<img src="../goots/gootshrug.png" alt=":gootshrug:" title=":gootshrug:" height="128" width="128">
+<img src="../goots/gootsie-guns.png" alt=":gootsie-guns:" title=":gootsie-guns:" height="128" width="128">
+<img src="../goots/neutro-goots.png" alt=":neutro-goots:" title=":neutro-goots:" height="128" width="128">
+<img src="../goots/oh-my-gootness.png" alt=":oh-my-gootness:" title=":oh-my-gootness:" height="128" width="128">
+<img src="../goots/thoots.png" alt=":thoots:" title=":thoots:" height="128" width="128">
+<img src="../goots/uno-reverso-blue.png" alt=":uno-reverso-blue:" title=":uno-reverso-blue:" height="128" width="128">
+<img src="../goots/uno-reverso-green.png" alt=":uno-reverso-green:" title=":uno-reverso-green:" height="128" width="128">
+<img src="../goots/uno-reverso-pink.png" alt=":uno-reverso-pink:" title=":uno-reverso-pink:" height="128" width="128">
+<img src="../goots/uno-reverso-purple.png" alt=":uno-reverso-purple:" title=":uno-reverso-purple:" height="128" width="128">
+<img src="../goots/uno-reverso-yellow.png" alt=":uno-reverso-yellow:" title=":uno-reverso-yellow:" height="128" width="128">
+<img src="../goots/wat-goots.png" alt=":wat-goots:" title=":wat-goots:" height="128" width="128">
+<img src="../goots/yeets.png" alt=":yeets:" title=":yeets:" height="128" width="128">
+
+</main>
+</body>
+</html>

--- a/picker/script.js
+++ b/picker/script.js
@@ -1,0 +1,60 @@
+"use strict";
+(() => {
+	/*[ Util ]***********************************************************************************/
+
+	/**
+	$() streamlines creating and getting elements.
+
+	Arguments:
+		str: String
+			Query selector or HTML to create.
+
+	Returns: HTMLElement | Array(HTMLElement)
+		The created or found element(s).
+	**/
+	function $(str) {
+		let res;
+		if (/</u.test(str)) {
+			res = document.createElement(null);
+			res = [...((res.innerHTML = str), res.children)];
+		} else {
+			res = [...document.querySelectorAll(str)];
+		}
+
+		return res.length < 2 ? res[0] : res;
+	}
+
+	/**
+	toast() displays a message in the toast bar for a period of time.
+
+	Arguments:
+		text: String
+			Text to display.
+		showMS: Number
+			Number of milliseconds to display the toast for.
+	**/
+	function toast(text, showMS = 3000) {
+		const msg = $(`<p>${text}</p>`);
+		$("#toast-bar").appendChild(msg);
+		setTimeout(msg.remove.bind(msg), showMS);
+	}
+
+	/*[ Main ]***********************************************************************************/
+
+	const HTML = $("html");
+	HTML.classList.add("js");
+	HTML.appendChild($('<aside id="toast-bar"></aside>'));
+	$("img").forEach((elm) => {
+		elm.onclick = () => {
+			navigator.clipboard.writeText(elm.alt).then(
+				() => {
+					toast(`Copied ${elm.alt} To Clipboard`);
+				},
+				() => {
+					toast(`Failed To Copy ${elm.alt} To Clipboard`);
+				}
+			);
+		};
+	});
+
+})();

--- a/picker/style.css
+++ b/picker/style.css
@@ -1,0 +1,89 @@
+/*[ Config ]***************************************************************************************/
+
+:root {
+	/* size is the height/width to display geets at. */
+	--size: 100px;
+}
+
+
+/*[ Reset ]****************************************************************************************/
+
+*,
+*::after,
+*::before {
+	border: 0;
+	box-sizing: inherit;
+	font-size: 100%;
+	font-style: inherit;
+	font-variant: none;
+	margin: 0;
+	padding: 0;
+	overflow: visible;
+	vertical-align: baseline;
+	overscroll-behavior: contain;
+}
+
+html {
+	-webkit-text-size-adjust: 100%;
+	-webkit-tap-highlight-color: transparent;
+}
+
+main {
+	display: block;
+}
+
+
+/*[ Toast Bar ]************************************************************************************/
+
+#toast-bar {
+	position: absolute;
+	bottom: 1em;
+	right: 2em;
+}
+
+#toast-bar p {
+	color: #fff;
+	background: rgba(0, 0, 0, .8);
+	margin: .5em 0 0 auto;
+	padding: .5em 1em;
+	border-radius: 3px;
+	width: fit-content;
+	font-family: sans-serif;
+
+	animation-duration: .25s;
+	animation-name: animate-fade-in;
+	animation-timing-function: ease-out;
+}
+
+@keyframes animate-fade-in {
+	0%   { opacity: 0; }
+	100% { opacity: 1; }
+}
+
+
+/*[ Main Style ]***********************************************************************************/
+
+html {
+	color: #fff;
+	background: #222;
+}
+
+main {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(var(--size), 1fr));
+	grid-template-rows: repeat(auto-fill, minmax(var(--size), 1fr));
+	place-items: center;
+	padding: 2em;
+	gap: .5em;
+}
+
+img {
+	height: var(--size);
+	width: var(--size);
+	transition: transform .05s ease-in;
+}
+
+/* Only enable zoom hover with JS to make manually copying pasting goots easier. */
+.js img:hover {
+	transform: scale(1.3);
+}


### PR DESCRIPTION
Had a bit more fun and made a browser based goots picker. Just open the `index.html` in any browser and click a goots to copy it to the clipboard. Helps keep all your goots in one place for the busy dev on the go.

![Screenshot 2024-06-07 at 23 57 34](https://github.com/christrotter/gootsmoji/assets/79859240/bcf69267-7654-4123-aed8-e7e55d039e16)

You can also `Cmd-A Cmd-C` then `Cmd-V` into Slack to test out all the names. Many work, but a few geets have different file names than slackmoji names:

![Screenshot 2024-06-08 at 00 25 26](https://github.com/christrotter/gootsmoji/assets/79859240/9aa85918-1981-4fa7-a350-5be0014c3e05)

It can also be extended by people to feature other common slackmoji, but why would you want to do that? Example with the `other/` folder added:

![Screenshot 2024-06-08 at 00 44 15](https://github.com/christrotter/gootsmoji/assets/79859240/d562d5db-d037-4ca8-9949-84dbb7c20630)