### PR TITLE
trying another approach

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -27,7 +27,6 @@ jobs:
 
       # We want to always regen the grid file; GHA does not make skipping based on file changes easy.
       - name: Update grid image
-        if: github.ref == 'refs/heads/main'
         run: |
           python build.py
           git rm --cached grid_image.png

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
 
       # We want to always regen the grid file; GHA does not make skipping based on file changes easy.
       - name: Update grid image
+        if: github.ref == 'refs/heads/main'
         run: |
           python build.py
           git rm --cached grid_image.png

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,18 +19,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
-      - name: Run build
+
+      # We want to always regen the grid file; GHA does not make skipping based on file changes easy.
+      - name: Update grid image
         run: |
           python build.py
-      - name: Update grid
-        if: github.ref == 'refs/heads/main'
-        with:
-          files: grid_image.png
-        run: |
+          git rm --cached grid_image.png
           git add grid_image.png
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Since the only point of this workflow is to regen the grid image file, simplifying it.

- always remove and add the grid_image.png file
- combine the generate/commit steps
- move the main filter up to the entire job