### PR TITLE
Fix toast location from absolute to fixed

### DIFF
--- a/picker/index.html
+++ b/picker/index.html
@@ -15,28 +15,30 @@ Re-generate by running the following in the goots/ directory and pasting the res
 ls | sed -ne 's|\(.*\)\.\(.*\)|<img src="../goots/\1.\2" alt=":\1:" title=":\1:" height="128" width="128">|p' | pbcopy
 -->
 
-<img src="../goots/angry-goots.png" alt=":angry-goots:" title=":angry-goots:" height="128" width="128">
 <img src="../goots/artificial-goots.png" alt=":artificial-goots:" title=":artificial-goots:" height="128" width="128">
-<img src="../goots/audiogoots.png" alt=":audiogoots:" title=":audiogoots:" height="128" width="128">
 <img src="../goots/bank-of-goots.png" alt=":bank-of-goots:" title=":bank-of-goots:" height="128" width="128">
 <img src="../goots/bank-of-goots2.png" alt=":bank-of-goots2:" title=":bank-of-goots2:" height="128" width="128">
-<img src="../goots/confu-goots.png" alt=":confu-goots:" title=":confu-goots:" height="128" width="128">
+<img src="../goots/cant-hear-goots.png" alt=":cant-hear-goots:" title=":cant-hear-goots:" height="128" width="128">
+<img src="../goots/confugoots.png" alt=":confugoots:" title=":confugoots:" height="128" width="128">
 <img src="../goots/dead-code-goots.png" alt=":dead-code-goots:" title=":dead-code-goots:" height="128" width="128">
+<img src="../goots/deadpool-goots.png" alt=":deadpool-goots:" title=":deadpool-goots:" height="128" width="128">
 <img src="../goots/eugene-goots.png" alt=":eugene-goots:" title=":eugene-goots:" height="128" width="128">
 <img src="../goots/fingie-goots.png" alt=":fingie-goots:" title=":fingie-goots:" height="128" width="128">
 <img src="../goots/goot-question.png" alt=":goot-question:" title=":goot-question:" height="128" width="128">
+<img src="../goots/goot-spinner.gif" alt=":goot-spinner:" title=":goot-spinner:" height="128" width="128">
 <img src="../goots/goot-toot-toot.png" alt=":goot-toot-toot:" title=":goot-toot-toot:" height="128" width="128">
 <img src="../goots/gootprised.png" alt=":gootprised:" title=":gootprised:" height="128" width="128">
 <img src="../goots/gootrage.png" alt=":gootrage:" title=":gootrage:" height="128" width="128">
 <img src="../goots/goots-80s-mullet-man.png" alt=":goots-80s-mullet-man:" title=":goots-80s-mullet-man:" height="128" width="128">
 <img src="../goots/goots-angry.png" alt=":goots-angry:" title=":goots-angry:" height="128" width="128">
-<img src="../goots/goots-cant-hear.png" alt=":goots-cant-hear:" title=":goots-cant-hear:" height="128" width="128">
 <img src="../goots/goots-celebration.png" alt=":goots-celebration:" title=":goots-celebration:" height="128" width="128">
 <img src="../goots/goots-embarassed.png" alt=":goots-embarassed:" title=":goots-embarassed:" height="128" width="128">
 <img src="../goots/goots-fight.png" alt=":goots-fight:" title=":goots-fight:" height="128" width="128">
 <img src="../goots/goots-heart.png" alt=":goots-heart:" title=":goots-heart:" height="128" width="128">
 <img src="../goots/goots-idea.png" alt=":goots-idea:" title=":goots-idea:" height="128" width="128">
 <img src="../goots/goots-intrigued.png" alt=":goots-intrigued:" title=":goots-intrigued:" height="128" width="128">
+<img src="../goots/goots-mullet.png" alt=":goots-mullet:" title=":goots-mullet:" height="128" width="128">
+<img src="../goots/goots-namaste.png" alt=":goots-namaste:" title=":goots-namaste:" height="128" width="128">
 <img src="../goots/goots-no-audio.png" alt=":goots-no-audio:" title=":goots-no-audio:" height="128" width="128">
 <img src="../goots/goots-no-no.png" alt=":goots-no-no:" title=":goots-no-no:" height="128" width="128">
 <img src="../goots/goots-no.png" alt=":goots-no:" title=":goots-no:" height="128" width="128">
@@ -47,8 +49,13 @@ ls | sed -ne 's|\(.*\)\.\(.*\)|<img src="../goots/\1.\2" alt=":\1:" title=":\1:"
 <img src="../goots/goots-yes.png" alt=":goots-yes:" title=":goots-yes:" height="128" width="128">
 <img src="../goots/gootshrug.png" alt=":gootshrug:" title=":gootshrug:" height="128" width="128">
 <img src="../goots/gootsie-guns.png" alt=":gootsie-guns:" title=":gootsie-guns:" height="128" width="128">
-<img src="../goots/neutro-goots.png" alt=":neutro-goots:" title=":neutro-goots:" height="128" width="128">
 <img src="../goots/oh-my-gootness.png" alt=":oh-my-gootness:" title=":oh-my-gootness:" height="128" width="128">
+<img src="../goots/party-goots.gif" alt=":party-goots:" title=":party-goots:" height="128" width="128">
+<img src="../goots/robogoots.png" alt=":robogoots:" title=":robogoots:" height="128" width="128">
+<img src="../goots/roger-goots-blue.png" alt=":roger-goots-blue:" title=":roger-goots-blue:" height="128" width="128">
+<img src="../goots/roger-goots-green.png" alt=":roger-goots-green:" title=":roger-goots-green:" height="128" width="128">
+<img src="../goots/roger-goots-pink.png" alt=":roger-goots-pink:" title=":roger-goots-pink:" height="128" width="128">
+<img src="../goots/roger-goots-purple.png" alt=":roger-goots-purple:" title=":roger-goots-purple:" height="128" width="128">
 <img src="../goots/thoots.png" alt=":thoots:" title=":thoots:" height="128" width="128">
 <img src="../goots/uno-reverso-blue.png" alt=":uno-reverso-blue:" title=":uno-reverso-blue:" height="128" width="128">
 <img src="../goots/uno-reverso-green.png" alt=":uno-reverso-green:" title=":uno-reverso-green:" height="128" width="128">

--- a/picker/style.css
+++ b/picker/style.css
@@ -36,7 +36,10 @@ main {
 /*[ Toast Bar ]************************************************************************************/
 
 #toast-bar {
-	position: absolute;
+	position: fixed;
+	display: flex;
+	flex-direction: column;
+	width: calc(100% - 3em);
 	bottom: 1em;
 	right: 2em;
 }
@@ -45,6 +48,8 @@ main {
 	color: #fff;
 	background: rgba(0, 0, 0, .8);
 	margin: .5em 0 0 auto;
+	align-self: flex-end;
+	margin-top: .5em;
 	padding: .5em 1em;
 	border-radius: 3px;
 	width: fit-content;


### PR DESCRIPTION
I messed up the toast bar location. If it's absolute, that puts it at the bottom of the page. If it's fixed, it puts it at the bottom of the viewport. They look the same until you have enough geets to require scrolling.

I also switched to a flexbox to make the display a little more interpretable than using an auto margin position.

Manually updated picker list.