### PR TITLE
Tidy github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,9 @@ jobs:
       - name: Update built assets
         run: |
           python build.py
-          if [[ -n "$(git status --porcelain)" ]]; then \
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git config user.name "github-actions[bot]"
-            git commit --all \
-              --message='Automatic Asset Rebuild'; \
-            git push; \
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git config user.name 'github-actions[bot]'
+            git commit --all --message='Automatic Asset Rebuild'
+            git push
           fi


### PR DESCRIPTION
Yep. Sometimes simpler is better... This just tidies up the config. Remove some of the unneeded newline wrapping stuff and switch to single quotes because we don't need variable expansion and escaping.