### PR TITLE
Add fix for non-RGBA formatted goots

### DIFF
--- a/wallpaper.py
+++ b/wallpaper.py
@@ -56,7 +56,7 @@ FONT_SPREAD = 4
 def main():
     """Generate the wallpaper."""
     images = [
-        Image.open(os.path.join(IMAGE_SOURCE_DIR, filename))
+        Image.open(os.path.join(IMAGE_SOURCE_DIR, filename)).convert("RGBA")
         for filename in os.listdir(IMAGE_SOURCE_DIR)
         if filename.endswith(".png")
     ]


### PR DESCRIPTION
A goots isn't RGBA formatted which causes the mask to fail (since an image mask by nature has to have transparency to pick what to mask). This should essentially be a noop for already RGBA images.