### PR TITLE
feat: goots importer / goots cannon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
 # gootsmoji
 Collection of very useful slack emojis.
 
-# preview 
+## Preview 
 ![Goots goots goots](grid_image.png?raw=true)
+
+## Gootsifying your Slack workspace
+
+You can sync available Goots at any time by running the bootstrap script (`. script/bootstrap`) and running the
+`import.py` script. Note that this requires a valid configuration file to be present.
+
+```bash
+python ./import.py <path-to-goots-config-json>
+```
+
+### Configuration
+
+The importer ("Goots Cannon") relies on the same APIs the app uses to avoid limitations due to Slack Enterprise. Because
+of this, you will need to supply two authentication tokens that you can retrieve by logging in via Slack web and inspecting your local storage and cookies.
+
+The first token, `xoxc`, is available under your browser's Local Storage if you look up the value of
+`localConfig_v2.teams.[team_id].token` and is of the form `xoxc-*`.
+
+The second token, `xoxd` is stored in a cookie named `d` attached to your Slack web session and is of the form `xoxd-*`.
+
+With those two tokens in hand, you can build a valid configuration file:
+
+```json
+{
+   "xoxc": "xoxc-...",
+   "xoxd": "xoxd-...",
+   "api_host": "my-slack-workspace.slack.com",
+}
+```
+
+Optionally, you can include a `assets_root` value which overrides the default for where the tool should find the goots
+(by default, `./goots`, where the PNGs live). You can also tweak the number of retries allowed in the event of rate
+limiting by defining `max_retries` (defaults to 5).

--- a/import.py
+++ b/import.py
@@ -1,0 +1,166 @@
+"""
+;;; GOOTS CANNON ;;;
+
+This tool syncs all the goots on record with the target Slack workspace
+regardless of whether the workspace is on Slack Enterprise or not. For this
+reason, it has to use an unstable API that mirror what the app / website
+hits.
+
+The Goots Cannon is idempotent and each run will attempt to push
+each goots emoji to the Slack workspace under the name they are saved
+as under `./goots`.
+"""
+
+import requests
+
+import pathlib
+import json
+import dataclasses
+import sys
+import time
+import typing
+import logging
+
+logger = logging.getLogger("goots-cannon")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(module)s: %(message)s",
+)
+
+
+@dataclasses.dataclass
+class Config:
+    """
+    Configuration schema for the file that sets up the Goots Cannon(tm)
+
+    This avoids having to include tokens in the shell, which might include
+    them in shell history or environment variables.
+    """
+
+    # Slack workspace host
+    api_host: str
+    # xoxd token extracted from session cookies when using the app
+    xoxd: str
+    # xoxc token extracted from LocalStorage configuration when using the app
+    xoxc: str
+    # Where the emoji assets live
+    assets_root: str = "./goots"
+    # Maximum number of times to retry an upload for non-critical errors
+    max_retries: int = 5
+
+
+@dataclasses.dataclass
+class Report:
+    """
+    Summary data describing the outcome of an import run.
+    """
+
+    successes: int = 0
+    failures: dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
+class SlackAPIResponse:
+    ok: str
+    error: typing.Optional[str] = None
+
+    _retryable_errors = ["ratelimited"]
+
+    @property
+    def retryable(self) -> bool:
+        return not self.ok and self.error in self._retryable_errors
+
+
+def bold(s: str) -> str:
+    """Bolds the selected text."""
+    return f"\033[1m{s}\033[0m"
+
+
+def load_configuration(path: pathlib.Path) -> Config:
+    """
+    Loads a configuration file into memory
+
+    This assumes that the file exists and that it contains valid
+    json, explicitly letting the caller to decide (or not) to handle
+    exceptions.
+    """
+    with open(path, "r", encoding="utf8") as conf_file:
+        config = Config(**json.load(conf_file))
+
+    return config
+
+
+def upload_emoji(
+    *, conf: Config, source: pathlib.Path, name: str, retry: int = 0
+) -> SlackAPIResponse:
+    """
+    Uploads a single emoji to the Slack workspace pointer to by conf.api_host.
+
+    The emoji is filed using its name as an emoji identifier.
+
+    Because the API enforces rate limiting, this retries up to conf.max_retries
+    if a retryable error is encountered. If the error is not retryable, the one upload
+    is deemed a failure.
+    """
+    with open(source, "rb") as source_file:
+        response = requests.post(
+            f"https://{conf.api_host}/api/emoji.add",
+            cookies={"d": conf.xoxd},
+            headers={},
+            data={
+                "token": conf.xoxc,
+                "name": source.stem,
+                "mode": "data",
+            },
+            files={"image": source_file.read()},
+        )
+
+    api_response = SlackAPIResponse(**response.json())
+
+    if api_response.retryable and retry < conf.max_retry:
+        time.sleep(0.1 * (1 + retry))
+        api_response = upload_emoji(
+            conf=conf, source=source, name=name, retry=retry + 1
+        )
+
+    return api_response
+
+
+def upload_emojis(
+    *,
+    conf: Config,
+    goots_root: pathlib.Path,
+) -> Report:
+    """
+    Uploads all the emojis listed under `goots_root`. Each upload is tried in isolation
+    and can fail independently.
+    """
+    report = Report()
+
+    for goot in goots_root.iterdir():
+        emoji_name = goot.stem
+        response = upload_emoji(conf=conf, source=goot, name=emoji_name)
+
+        if response.ok:
+            report.successes += 1
+        else:
+            report.failures[emoji_name] = response.error
+
+    return report
+
+
+if __name__ == "__main__":
+    conf_path = pathlib.Path(sys.argv[1])
+    conf = load_configuration(conf_path)
+    assets_root = pathlib.Path(conf.assets_root)
+
+    logger.info(f"Preparing to sync {bold(len(list(assets_root.iterdir())))} goots!\n")
+
+    report = upload_emojis(conf=conf, goots_root=assets_root)
+
+    logger.info(
+        f"{report.successes} new goots uploaded, {len(report.failures)} failures.\n"
+    )
+    logger.info("=== Failure breakdown ===")
+    for name, reason in report.failures.items():
+        logger.info(f"{name}: {reason}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Pillow==10.3.0
+requests


### PR DESCRIPTION
# Behold, the 🪿 GOOTS CANNON 🔫 

This resolves #60 with the `import.py` script, which syncs the available Goots emojis with the target workspace provided that you have credentials to access the workspace yourself.

# Token and API trickery

This uses the undocumented Emojis API that the Slack app uses to allow uses to add emojis without regardless of enterprise status. The only [other documented alternative](https://api.slack.com/methods/admin.emoji.add) is explicitly scoped to Enterprise workpaces, which is unfair as the world needs more Goots, not just the bougeoisie.

A caveat of this approach is that _your mileage may vary_: Slack probably doesn't expect anyone to rely on this and it's subject to breaking changes. That being said, I would think it's a pretty stable API since not a lot of emoji-related features are being added by the Slack team.

Tokens requires for this to work are available by digging in local data stored by Slack in the browser (see the README additions for details) and seem pretty stable - tokens I generated a few days ago are still active and work well. I suspect that they are invalidated if I terminate my Slack session, but the lifetime of those is pretty large.

# Beautiful idempotency

The script goes through all available emojis and pushes them up, either succeeding or failing if the name is already registered (or if the request is rate-limited, see further down). As such, it's a true "Goots sync" that can be run periodically to ensure that the latest Goots are loaded in your workspace. Failures in this case are scoped to each emoji such that the first run is expected to push all Goots up, then the subsequent ones should fail on all of them except the ones you don't have.

# Clever retrying

Slack's API reacts poorly to quickfire requests. Rudimentary retrying is included so that when a "retryable" error is encountered, the request is retried a few times at varying intervals before giving up.